### PR TITLE
fix: mutual friends in a drawer to declutter profiles

### DIFF
--- a/src/views/userProfile.tsx
+++ b/src/views/userProfile.tsx
@@ -115,7 +115,6 @@ const ProfileView: Component = () => {
                   Became friends on {new Date(profile().relationship.friendedAt).toLocaleString()}
                 </p>
               </div>
-              </Show>
             </>
           )}
         </Show>


### PR DESCRIPTION
The mutual friends list is moved to a drawer to make room for future pinned posts. The drawer looks the same as the realmoji drawer but without the emojis.


![image](https://github.com/user-attachments/assets/cc1c16e3-a876-4e78-9954-69281d61af6a)
